### PR TITLE
Refactor stats output and enhance download management features

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -696,13 +696,11 @@ app.get("/downloads/:token", async (c) => {
       return c.json(
         {
           error: "Download not found or expired",
-          message: "The download link may have expired. Downloads are valid for 24 hours.",
+          message: "The download link may have expired. Downloads are valid for 5 hours.",
         },
         404,
       );
     }
-
-    const fileStream = createReadStream(entry.filePath);
 
     // Set response headers for file download
     c.header("Content-Type", entry.mimeType);
@@ -712,7 +710,34 @@ app.get("/downloads/:token", async (c) => {
     c.header("Pragma", "no-cache");
     c.header("Expires", "0");
 
-    return c.body(fileStream as never);
+    // Use ReadableStream to properly handle file streaming without closing the stream prematurely
+    const readable = createReadStream(entry.filePath);
+
+    return new Promise((resolve) => {
+      const chunks: Buffer[] = [];
+
+      readable.on("data", (chunk) => {
+        if (Buffer.isBuffer(chunk)) {
+          chunks.push(chunk);
+        } else {
+          chunks.push(Buffer.from(chunk));
+        }
+      });
+
+      readable.on("end", () => {
+        resolve(c.body(Buffer.concat(chunks)));
+      });
+
+      readable.on("error", (error) => {
+        readable.destroy();
+        resolve(
+          c.json(
+            { error: "Failed to read file", details: String(error) },
+            500,
+          ),
+        );
+      });
+    });
   } catch (error) {
     return c.json(
       { error: "Failed to serve download", details: String(error) },

--- a/src/app/commands/DownloaderCommand.ts
+++ b/src/app/commands/DownloaderCommand.ts
@@ -37,7 +37,7 @@ export class DownloaderCommand extends CommandInterface {
   };
 
   private ytdl = new YtDlpWrapper();
-  private readonly SEND_TIMEOUT = 300000; // 5 minutes timeout
+  private readonly SEND_TIMEOUT = 1800000; // 30 minutes timeout (for large file downloads)
   private readonly MAX_MEDIA_SIZE_MB = 100; // Limit for normal media send
   private readonly MAX_DOCUMENT_SIZE_MB = 1000; // 1GB absolute limit
   private readonly TIKTOK_USER_AGENT = "curl/8.4.0";

--- a/src/app/commands/DownloaderCommand.ts
+++ b/src/app/commands/DownloaderCommand.ts
@@ -39,7 +39,7 @@ export class DownloaderCommand extends CommandInterface {
   private ytdl = new YtDlpWrapper();
   private readonly SEND_TIMEOUT = 1800000; // 30 minutes timeout (for large file downloads)
   private readonly MAX_MEDIA_SIZE_MB = 100; // Limit for normal media send
-  private readonly MAX_DOCUMENT_SIZE_MB = 1000; // 1GB absolute limit
+  private readonly MAX_DOCUMENT_SIZE_MB = 512; // 512MB absolute limit
   private readonly TIKTOK_USER_AGENT = "curl/8.4.0";
 
   async handleCommand(

--- a/src/app/commands/DownloaderCommand.ts
+++ b/src/app/commands/DownloaderCommand.ts
@@ -14,6 +14,10 @@ import {
   registerPublicDownload,
   removePublicDownload,
 } from "../../shared/utils/publicDownloadStore.js";
+import {
+  DownloadQueueManager,
+  startDownloadQueueCleanup,
+} from "../../shared/utils/downloadQueue.js";
 
 export class DownloaderCommand extends CommandInterface {
   static commandInfo: CommandInfo = {
@@ -41,6 +45,15 @@ export class DownloaderCommand extends CommandInterface {
   private readonly MAX_MEDIA_SIZE_MB = 100; // Limit for normal media send
   private readonly MAX_DOCUMENT_SIZE_MB = 512; // 512MB absolute limit
   private readonly TIKTOK_USER_AGENT = "curl/8.4.0";
+  private queueManager = DownloadQueueManager.getInstance();
+
+  constructor() {
+    super();
+    // Initialize cleanup scheduler on first instantiation
+    if (!this.queueManager) {
+      startDownloadQueueCleanup();
+    }
+  }
 
   async handleCommand(
     args: string[],
@@ -111,6 +124,27 @@ export class DownloaderCommand extends CommandInterface {
       });
       return;
     }
+
+    // Check download queue
+    const queueEntry = this.queueManager.addToQueue({
+      id: `${jid}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      url,
+      jid,
+      user,
+      timestamp: Date.now(),
+      status: "pending",
+    });
+    const downloadId = `${jid}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+    if (!this.queueManager.canStart()) {
+      await sock.sendMessage(jid, {
+        text: `⏳ Download Anda dalam antrian.\n📍 Posisi: ${queueEntry.position + 1}/${queueEntry.queueSize}\n⏸️ Tunggu giliran Anda...`,
+      });
+      return;
+    }
+
+    // Mark download as started
+    this.queueManager.startDownload(downloadId);
 
     try {
       const statusMsg = await sock.sendMessage(jid, {
@@ -327,9 +361,12 @@ export class DownloaderCommand extends CommandInterface {
           edit: progressMessageKey,
         });
       }
+      this.queueManager.completeDownload(downloadId);
       return;
     } catch (error) {
       log.error("Download failed:", error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.queueManager.failDownload(downloadId, errorMessage);
       await this.handleDownloadError(error, sock, jid);
       return;
     }

--- a/src/app/handlers/CommandHandler.ts
+++ b/src/app/handlers/CommandHandler.ts
@@ -843,12 +843,11 @@ export class CommandHandler {
 `;
 
         statsText =
+          systemStats +
           "Statistik penggunaan perintah:\n" +
           Object.entries(byCommand)
             .map(([cmd, count], i) => `${i + 1}. *${cmd}*: ${count}x`)
-            .join("\n") +
-          "\n\n" +
-          systemStats;
+            .join("\n");
       }
     }
     await sock.sendMessage(jid, { text: statsText });

--- a/src/shared/utils/downloadQueue.ts
+++ b/src/shared/utils/downloadQueue.ts
@@ -1,0 +1,205 @@
+import { log } from "../../infrastructure/config/config.js";
+
+export interface QueuedDownload {
+  id: string;
+  url: string;
+  jid: string;
+  user: string;
+  timestamp: number;
+  status: "pending" | "processing" | "completed" | "failed";
+  error?: string;
+}
+
+/**
+ * DownloadQueueManager - Manages concurrent downloads to prevent resource exhaustion
+ * Limits the number of simultaneous downloads and queues the rest
+ */
+export class DownloadQueueManager {
+  private static instance: DownloadQueueManager;
+  private queue: Map<string, QueuedDownload> = new Map();
+  private activeDownloads = new Set<string>();
+  private readonly MAX_CONCURRENT = 2; // Limit to 2 concurrent downloads
+  private readonly QUEUE_TIMEOUT = 3600000; // 1 hour timeout for queued items
+
+  private constructor() {}
+
+  static getInstance(): DownloadQueueManager {
+    if (!DownloadQueueManager.instance) {
+      DownloadQueueManager.instance = new DownloadQueueManager();
+    }
+    return DownloadQueueManager.instance;
+  }
+
+  /**
+   * Add a download to the queue
+   */
+  addToQueue(download: QueuedDownload): { position: number; queueSize: number } {
+    const id = `${download.jid}-${download.timestamp}-${Math.random().toString(36).slice(2, 9)}`;
+    const queuedItem = { ...download, id, status: "pending" as const };
+    this.queue.set(id, queuedItem);
+
+    log.info(`Added download to queue: ${id} (Queue size: ${this.queue.size})`);
+
+    const position = this.getQueuePosition(id);
+    return { position, queueSize: this.queue.size };
+  }
+
+  /**
+   * Check if a download can start (under concurrent limit)
+   */
+  canStart(): boolean {
+    return this.activeDownloads.size < this.MAX_CONCURRENT;
+  }
+
+  /**
+   * Get the position of a download in the queue
+   */
+  getQueuePosition(id: string): number {
+    if (!this.queue.has(id)) return -1;
+
+    let position = 0;
+    for (const [key, item] of this.queue.entries()) {
+      if (key === id) break;
+      if (item.status === "pending") position++;
+    }
+    return position;
+  }
+
+  /**
+   * Get queue size (pending items)
+   */
+  getQueueSize(): number {
+    return Array.from(this.queue.values()).filter(
+      (item) => item.status === "pending",
+    ).length;
+  }
+
+  /**
+   * Start processing a download (mark as active)
+   */
+  startDownload(id: string): void {
+    const item = this.queue.get(id);
+    if (item) {
+      item.status = "processing";
+      this.activeDownloads.add(id);
+      log.info(
+        `Download started: ${id} (Active: ${this.activeDownloads.size}/${this.MAX_CONCURRENT})`,
+      );
+    }
+  }
+
+  /**
+   * Mark a download as completed
+   */
+  completeDownload(id: string): void {
+    const item = this.queue.get(id);
+    if (item) {
+      item.status = "completed";
+      this.activeDownloads.delete(id);
+      // Keep in queue for a bit for status tracking, auto-cleanup handled by janitor
+      log.info(`Download completed: ${id} (Active: ${this.activeDownloads.size})`);
+    }
+  }
+
+  /**
+   * Mark a download as failed
+   */
+  failDownload(id: string, error: string): void {
+    const item = this.queue.get(id);
+    if (item) {
+      item.status = "failed";
+      item.error = error;
+      this.activeDownloads.delete(id);
+      log.warn(
+        `Download failed: ${id} - ${error} (Active: ${this.activeDownloads.size})`,
+      );
+    }
+  }
+
+  /**
+   * Get download details by ID
+   */
+  getDownload(id: string): QueuedDownload | undefined {
+    return this.queue.get(id);
+  }
+
+  /**
+   * Get all pending downloads for a user
+   */
+  getUserDownloads(jid: string): QueuedDownload[] {
+    return Array.from(this.queue.values()).filter(
+      (item) => item.jid === jid && item.status === "pending",
+    );
+  }
+
+  /**
+   * Get all active downloads
+   */
+  getActiveDownloads(): QueuedDownload[] {
+    return Array.from(this.queue.values()).filter(
+      (item) => item.status === "processing",
+    );
+  }
+
+  /**
+   * Cleanup old/completed entries (called periodically)
+   */
+  cleanup(): void {
+    const now = Date.now();
+    const expired: string[] = [];
+
+    for (const [id, item] of this.queue.entries()) {
+      const age = now - item.timestamp;
+
+      // Remove completed items older than 5 minutes
+      if (item.status === "completed" && age > 5 * 60 * 1000) {
+        expired.push(id);
+      }
+      // Remove failed items older than 5 minutes
+      else if (item.status === "failed" && age > 5 * 60 * 1000) {
+        expired.push(id);
+      }
+      // Remove pending items older than 1 hour (likely abandoned)
+      else if (item.status === "pending" && age > this.QUEUE_TIMEOUT) {
+        expired.push(id);
+      }
+    }
+
+    for (const id of expired) {
+      this.queue.delete(id);
+    }
+
+    if (expired.length > 0) {
+      log.info(`Cleaned up ${expired.length} old download queue entries`);
+    }
+  }
+
+  /**
+   * Get queue statistics
+   */
+  getStats(): {
+    pending: number;
+    active: number;
+    completed: number;
+    failed: number;
+    queueLength: number;
+  } {
+    const items = Array.from(this.queue.values());
+    return {
+      pending: items.filter((i) => i.status === "pending").length,
+      active: items.filter((i) => i.status === "processing").length,
+      completed: items.filter((i) => i.status === "completed").length,
+      failed: items.filter((i) => i.status === "failed").length,
+      queueLength: items.length,
+    };
+  }
+}
+
+/**
+ * Start automatic cleanup scheduler
+ */
+export function startDownloadQueueCleanup(): NodeJS.Timeout {
+  return setInterval(() => {
+    DownloadQueueManager.getInstance().cleanup();
+  }, 5 * 60 * 1000); // Every 5 minutes
+}

--- a/src/shared/utils/publicDownloadStore.ts
+++ b/src/shared/utils/publicDownloadStore.ts
@@ -12,7 +12,7 @@ export interface PublicDownloadEntry {
   expiresAt: number;
 }
 
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const DEFAULT_TTL_MS = 5 * 60 * 60 * 1000; // 5 hours
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour cleanup check
 
 const downloadStore = new Map<string, PublicDownloadEntry>();

--- a/src/shared/utils/ytdlp.ts
+++ b/src/shared/utils/ytdlp.ts
@@ -102,7 +102,7 @@ export interface YtDlpStreamResult {
 export class YtDlpWrapper {
   private cookiesFile: string;
   private readonly DOWNLOAD_TIMEOUT = 300000; // 5 minutes timeout
-  private readonly MAX_DURATION = 600; // 10 minutes limit
+  private readonly MAX_DURATION = 3600; // 60 minutes limit (large files served via public CDN)
   private useAria2c: boolean = false; // Enable aria2c by default for speed
 
   constructor(cookiesFile: string = "cookies.txt", useAria2c: boolean = false) {


### PR DESCRIPTION
This pull request introduces a download queue management system to control concurrent downloads and prevent resource exhaustion. It also adjusts download limits and expiration times, and improves error handling and user feedback for download operations. The most significant changes are the addition of a queue manager for downloads, updates to download timeouts and file size limits, and a reduction in public download link validity.

**Download queue management and concurrency control:**

* Added a new `DownloadQueueManager` class in `downloadQueue.ts` to manage concurrent downloads, limit the number of simultaneous downloads to 2, queue excess requests, and provide automatic cleanup of old entries. This includes methods for adding to the queue, tracking status, and cleaning up expired or completed downloads.
* Integrated the download queue manager into `DownloaderCommand.ts` so that new download requests are queued if the concurrent limit is reached, users are notified of their queue position, and downloads are marked as started, completed, or failed appropriately. [[1]](diffhunk://#diff-9b25e8ffd422300a76d98480a7a2b5cafb0e4c6e3148fbe8d098e04650c4816eR17-R20) [[2]](diffhunk://#diff-9b25e8ffd422300a76d98480a7a2b5cafb0e4c6e3148fbe8d098e04650c4816eL40-R56) [[3]](diffhunk://#diff-9b25e8ffd422300a76d98480a7a2b5cafb0e4c6e3148fbe8d098e04650c4816eR128-R148) [[4]](diffhunk://#diff-9b25e8ffd422300a76d98480a7a2b5cafb0e4c6e3148fbe8d098e04650c4816eR364-R369)

**Download and file handling limits:**

* Reduced the maximum allowed document size for downloads from 1GB to 512MB and increased the send timeout from 5 minutes to 30 minutes to better accommodate large file transfers.
* Increased the maximum allowed media duration for downloads from 10 minutes to 60 minutes, allowing longer media files to be downloaded (typically served via public CDN).

**Download link validity and expiration:**

* Reduced the default time-to-live for public download links from 24 hours to 5 hours, and updated user-facing error messages to reflect this new expiration window. [[1]](diffhunk://#diff-2c8e55b5d67dd7a6926e5467fff7b1c900cd6b99c6e2bb10087827b445bc32eaL15-R15) [[2]](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700L699-L706)

**File streaming improvements:**

* Changed the file streaming implementation in the downloads API endpoint to use a `ReadableStream` and buffer the response, improving reliability and error handling during file downloads.

**Miscellaneous:**

* Fixed the order of statistics display in command handler output to show system stats before command usage.