### PR TITLE
fix: Fix sticker creation image format error

### DIFF
--- a/SYSTEM_MAP.md
+++ b/SYSTEM_MAP.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - **map_version**: 1.0.0
-- **last_updated**: 2026-06-27
+- **last_updated**: 2026-07-05
 - **last_updated_by**: agent/b4048922-83ae-4e2f-a6d8-c4636831e00c
 
 ## Project Overview
@@ -162,5 +162,6 @@ WhatsApp bot with AI integration and modular command system. Built with TypeScri
 - **2026-06-27** [patch] (agent/6b0e1efd-8c9d-4d88-97c0-16f329b7d8fe): Fixed animated sticker transparent background glitch on WhatsApp Desktop/Web by changing pixel format to rgba.
 - **2026-06-27** [minor] (agent/6b0e1efd-8c9d-4d88-97c0-16f329b7d8fe): Added auxiliary vision model pipeline in AskAICommand to process image inputs on text-only models (like DeepSeek).
 - **2026-06-27** [patch] (agent/b4048922-83ae-4e2f-a6d8-c4636831e00c): Fixed database collection caching reconnect disconnects, progressive reconnection logout loop, implemented recursive wrapper message extraction, and integrated MongoDB-backed message store in BotClient.
+- **2026-07-05** [patch] (agent/b4048922-83ae-4e2f-a6d8-c4636831e00c): Fixed sticker creation image format error by using safe TypedArray constructor instead of raw Buffer.buffer references.
 
 

--- a/src/app/commands/StickerCommand.ts
+++ b/src/app/commands/StickerCommand.ts
@@ -604,14 +604,14 @@ export class StickerCommand extends CommandInterface {
           const result = await workerPool.run<Uint8Array>(
             processorPath,
             "createAnimatedSticker",
-            [new Uint8Array(mediaBuffer.buffer), useCrop, sourceExtension],
+            [new Uint8Array(mediaBuffer), useCrop, sourceExtension],
           );
           stickerBuffer = Buffer.from(result);
         } else {
           const result = await workerPool.run<Uint8Array>(
             processorPath,
             "createSticker",
-            [new Uint8Array(mediaBuffer.buffer), useCrop],
+            [new Uint8Array(mediaBuffer), useCrop],
           );
           stickerBuffer = Buffer.from(result);
         }
@@ -624,7 +624,7 @@ export class StickerCommand extends CommandInterface {
           processorPath,
           "addExif",
           [
-            new Uint8Array(stickerBuffer.buffer),
+            new Uint8Array(stickerBuffer),
             sanitizedPackName,
             sanitizedAuthorName,
           ],


### PR DESCRIPTION
Replace raw `buffer.buffer` references with direct Buffer arguments to `new Uint8Array()`, preventing detached ArrayBuffer errors in sticker processing.